### PR TITLE
Fix non root build

### DIFF
--- a/2.1/build/build-rpms.sh
+++ b/2.1/build/build-rpms.sh
@@ -36,3 +36,5 @@ cd ~/rpmbuild/SOURCES && \
 cd ~/rpmbuild/SOURCES && \
     rpmbuild -ba cc-oci-runtime.spec
 
+# Copy RPMs
+cp ~/rpmbuild/RPMS/x86_64/* ~/build/

--- a/2.1/build/centos/Dockerfile
+++ b/2.1/build/centos/Dockerfile
@@ -106,10 +106,18 @@ RUN wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
-# Set $GOPATH and $HOME env variables
-RUN mkdir -p /root/go
-ENV GOPATH /root/go
-ENV HOME /root
-WORKDIR $HOME
+# Create a clear containers (cc) user
+ENV USER cc
+ENV HOME /home/cc
+RUN useradd -u 1000 -U -d ${HOME} -s /bin/bash ${USER}
+
+USER    ${USER}
+WORKDIR ${HOME}
+
+RUN mkdir -p /home/cc/go
+ENV GOPATH /home/cc/go
+
+RUN mkdir -p /home/cc/rpmbuild/SOURCES
+COPY SOURCES/* /home/cc/rpmbuild/SOURCES/
 
 CMD ["/bin/bash"]

--- a/2.1/build/centos/README.md
+++ b/2.1/build/centos/README.md
@@ -1,15 +1,20 @@
 # Build the CentOS builder Docker container 
-As root, run:
 
 ```
 # docker build -t centos-clear-containers .
 ```
 
 # Generate the qemu-lite & cc-oci-runtime rpms just run this:
-As root, run:
+
+## Host build directory
+
+The RPMs will be copied into a directory of your choice, e.g. `/tmp/build`
+Make sure you have write access on that directory.
 
 ```
+# export BUILD_DIR=/tmp/build
 # export VERSION=2.1.1
-# docker run -ti --rm -v $PWD/../rpmbuild:/root/rpmbuild -v $PWD/../build-rpms.sh:/usr/bin/build-rpms.sh centos-clear-containers /usr/bin/build-rpms.sh $VERSION
+# docker run -ti --rm -v $BUILD_DIR:/home/cc/build -v $PWD/../build-rpms.sh:/usr/bin/build-rpms.sh centos-clear-containers /usr/bin/build-rpms.sh $VERSION
 ```
-The rpms for cc-oci-runtime & qemu-lite will be at `$PWD/../rpmbuild/RPMS/x86_64`
+
+The rpms for cc-oci-runtime & qemu-lite will be at `$BUILD_DIR`

--- a/2.1/build/centos/SOURCES/cc-oci-runtime.spec-template
+++ b/2.1/build/centos/SOURCES/cc-oci-runtime.spec-template
@@ -1,0 +1,131 @@
+%undefine _missing_build_ids_terminate_build
+Name:      cc-oci-runtime
+Version:   VERSION
+Release:   0
+Source0:   %{name}-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Summary  : No detailed summary available
+Group    : Development/Tools
+License  : Apache-2.0 GPL-2.0
+Requires: cc-oci-runtime-bin
+Requires: cc-oci-runtime-config
+Requires: cc-oci-runtime-data
+Requires:  clear-containers-image
+Requires:  clear-containers-selinux
+Requires:  qemu-lite
+Requires:  linux-container
+
+%description
+.. contents::
+.. sectnum::
+``cc-oci-runtime``
+===================
+Overview
+--------
+
+%package bin
+Summary: bin components for the cc-oci-runtime package.
+Group: Binaries
+Requires: cc-oci-runtime-data
+Requires: cc-oci-runtime-config
+
+%description bin
+bin components for the cc-oci-runtime package.
+
+%package config
+Summary: config components for the cc-oci-runtime package.
+Group: Default
+
+%description config
+config components for the cc-oci-runtime package.
+
+%package data
+Summary: data components for the cc-oci-runtime package.
+Group: Data
+
+%description data
+data components for the cc-oci-runtime package.
+
+%package extras
+Summary: extras components for the cc-oci-runtime package.
+Group: Default
+
+%description extras
+extras components for the cc-oci-runtime package.
+
+%prep
+%setup -q -n cc-oci-runtime-PACKAGE
+
+%build
+export LANG=C
+sh ./autogen.sh --disable-static --enable-valgrind \
+--disable-cppcheck \
+--disable-tests \
+--disable-valgrind-memcheck \
+--disable-functional-tests \
+--disable-docker-tests \
+--with-cc-kernel=/usr/share/clear-containers/vmlinux.container \
+--with-cc-image=/usr/share/clear-containers/clear-containers.img \
+--with-cc-image-systemdsystemunitdir=/usr/lib/systemd/system \
+--enable-autogopath
+make V=1  %{?_smp_mflags}
+
+%check
+export LANG=C
+export http_proxy=http://127.0.0.1:9/
+export https_proxy=http://127.0.0.1:9/
+export no_proxy=localhost
+make VERBOSE=1 V=1 check
+
+%install
+rm -rf %{buildroot}
+%make_install
+
+%files
+%defattr(-,root,root,-)
+/usr/share/defaults/cc-oci-runtime/genfile.sh
+
+%files bin
+%defattr(-,root,root,-)
+/usr/bin/cc-oci-runtime
+/usr/bin/cc-oci-runtime.sh
+/usr/libexec/cc-proxy
+/usr/libexec/cc-shim
+
+%files config
+%defattr(-,root,root,-)
+%exclude /usr/lib/systemd/system/cc-agent.service
+%exclude /usr/lib/systemd/system/cc-agent.target
+%exclude /usr/lib/systemd/system/container-workload.service
+%exclude /usr/lib/systemd/system/container.target
+%exclude /usr/lib/systemd/system/opt-rootfs-proc.mount
+%exclude /usr/lib/systemd/system/opt-rootfs-sys.mount
+%exclude /usr/lib/systemd/system/opt-rootfs.mount
+/usr/lib/systemd/system/cc-proxy.service
+/usr/lib/systemd/system/cc-proxy.socket
+
+%files data
+%defattr(-,root,root,-)
+%if 0%{?suse_version}
+%dir /usr/share/defaults
+%dir /usr/share/defaults/cc-oci-runtime
+%endif
+/usr/share/defaults/cc-oci-runtime/hypervisor.args
+/usr/share/defaults/cc-oci-runtime/kernel-cmdline
+/usr/share/defaults/cc-oci-runtime/vm.json
+
+
+%files extras
+%defattr(-,root,root,-)
+/usr/lib/systemd/system/cc-agent.service
+/usr/lib/systemd/system/cc-agent.target
+/usr/lib/systemd/system/container-workload.service
+/usr/lib/systemd/system/container.target
+/usr/lib/systemd/system/opt-rootfs-proc.mount
+/usr/lib/systemd/system/opt-rootfs-sys.mount
+/usr/lib/systemd/system/opt-rootfs.mount
+
+%post
+/usr/bin/systemctl enable cc-proxy.socket
+/usr/bin/systemctl daemon-reload
+/usr/bin/systemctl restart cc-proxy.socket

--- a/2.1/build/centos/SOURCES/configure.patch
+++ b/2.1/build/centos/SOURCES/configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index 0c0472a..5cdb77e 100755
+--- a/configure
++++ b/configure
+@@ -1145,7 +1145,6 @@ for opt do
+   *)
+       echo "ERROR: unknown option $opt"
+       echo "Try '$0 --help' for more information"
+-      exit 1
+   ;;
+   esac
+ done

--- a/2.1/build/centos/SOURCES/qemu-lite.spec
+++ b/2.1/build/centos/SOURCES/qemu-lite.spec
@@ -1,0 +1,214 @@
+%undefine _missing_build_ids_terminate_build
+Name: qemu-lite
+Version: 2.7.1
+Release: 0
+Source0: https://github.com/01org/qemu-lite/archive/da5004e3ffc6a79df82d1b9d8f8533c4045f193c.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
+Summary  : OpenBIOS development utilities
+Group    : Development/Tools
+License  : Apache-2.0 BSD-2-Clause BSD-3-Clause GPL-2.0 GPL-2.0+ GPL-3.0 LGPL-2.0+ LGPL-2.1 LGPL-3.0 MIT
+Requires: qemu-lite-bin
+Requires: qemu-lite-data
+Patch1: configure.patch
+
+%description
+This package contains the OpenBIOS development new utilities.
+
+There are
+* toke - an IEEE 1275-1994 compliant FCode tokenizer
+* detok - an IEEE 1275-1994 compliant FCode detokenizer
+* paflof - a forth kernel running in user space
+* an fcode bytecode evaluator running in paflof
+
+See /usr/share/doc/packages/openbios for details and examples.
+
+Authors:
+--------
+    Stefan Reinauer <stepan@openbios.net>
+    Segher Boessenkool <segher@openbios.net>
+
+%package bin
+Summary: bin components for the qemu-lite package.
+Group: Binaries
+Requires: qemu-lite-data
+
+%description bin
+bin components for the qemu-lite package.
+
+
+%package data
+Summary: data components for the qemu-lite package.
+Group: Data
+
+%description data
+data components for the qemu-lite package.
+
+
+%prep
+%setup -q -n qemu-lite-da5004e3ffc6a79df82d1b9d8f8533c4045f193c
+%patch1 -p1
+
+%build
+export LANG=C
+CC=gcc ./configure --prefix=/usr --disable-bluez \
+--disable-brlapi \
+--disable-bzip2 \
+--disable-curl \
+--disable-curses \
+--disable-debug-tcg \
+--disable-fdt \
+--disable-glusterfs \
+--disable-gtk \
+--disable-libiscsi \
+--disable-libnfs \
+--disable-libssh2 \
+--disable-libusb \
+--disable-linux-aio \
+--disable-lzo \
+--disable-opengl \
+--disable-qom-cast-debug \
+--disable-rbd \
+--disable-rdma \
+--disable-sdl \
+--disable-seccomp \
+--disable-slirp \
+--disable-snappy \
+--disable-spice \
+--disable-strip \
+--disable-tcg-interpreter \
+--disable-tcmalloc \
+--disable-tools \
+--disable-tpm \
+--disable-usb-redir \
+--disable-uuid \
+--disable-vnc \
+--disable-vnc-jpeg \
+--disable-vnc-png \
+--disable-vnc-sasl \
+--disable-vte \
+--disable-xen \
+--enable-attr \
+--enable-cap-ng \
+--enable-kvm \
+--enable-virtfs \
+--target-list=x86_64-softmmu \
+--extra-cflags="-fno-semantic-interposition -O3 -falign-functions=32" \
+--datadir=/usr/share/qemu-lite \
+--libdir=/usr/lib64/qemu-lite \
+--libexecdir=/usr/libexec/qemu-lite \
+--enable-vhost-net \
+--disable-docs
+make V=1  %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+%make_install
+## make_install_append content
+for file in %{buildroot}/usr/bin/*
+do
+dir=$(dirname "$file")
+bin=$(basename "$file")
+new=$(echo "$bin"|sed -e 's/qemu-/qemu-lite-/g' -e 's/ivshmem-/ivshmem-lite-/g' -e 's/virtfs-/virtfs-lite-/g')
+mv "$file" "$dir/$new"
+done
+## make_install_append end
+
+%files
+%defattr(-,root,root,-)
+
+%files bin
+%defattr(-,root,root,-)
+/usr/bin/qemu-lite-ga
+/usr/bin/qemu-lite-system-x86_64
+/usr/bin/virtfs-lite-proxy-helper
+%dir /usr/libexec
+%dir /usr/libexec/qemu-lite
+/usr/libexec/qemu-lite/qemu-bridge-helper
+
+%files data
+%defattr(-,root,root,-)
+%dir /usr/share/qemu-lite
+%dir /usr/share/qemu-lite/qemu
+%dir /usr/share/qemu-lite/qemu/keymaps
+/usr/share/qemu-lite/qemu/QEMU,cgthree.bin
+/usr/share/qemu-lite/qemu/QEMU,tcx.bin
+/usr/share/qemu-lite/qemu/acpi-dsdt.aml
+/usr/share/qemu-lite/qemu/bamboo.dtb
+/usr/share/qemu-lite/qemu/bios-256k.bin
+/usr/share/qemu-lite/qemu/bios.bin
+/usr/share/qemu-lite/qemu/efi-e1000.rom
+/usr/share/qemu-lite/qemu/efi-e1000e.rom
+/usr/share/qemu-lite/qemu/efi-eepro100.rom
+/usr/share/qemu-lite/qemu/efi-ne2k_pci.rom
+/usr/share/qemu-lite/qemu/efi-pcnet.rom
+/usr/share/qemu-lite/qemu/efi-rtl8139.rom
+/usr/share/qemu-lite/qemu/efi-virtio.rom
+/usr/share/qemu-lite/qemu/efi-vmxnet3.rom
+/usr/share/qemu-lite/qemu/keymaps/ar
+/usr/share/qemu-lite/qemu/keymaps/bepo
+/usr/share/qemu-lite/qemu/keymaps/common
+/usr/share/qemu-lite/qemu/keymaps/cz
+/usr/share/qemu-lite/qemu/keymaps/da
+/usr/share/qemu-lite/qemu/keymaps/de
+/usr/share/qemu-lite/qemu/keymaps/de-ch
+/usr/share/qemu-lite/qemu/keymaps/en-gb
+/usr/share/qemu-lite/qemu/keymaps/en-us
+/usr/share/qemu-lite/qemu/keymaps/es
+/usr/share/qemu-lite/qemu/keymaps/et
+/usr/share/qemu-lite/qemu/keymaps/fi
+/usr/share/qemu-lite/qemu/keymaps/fo
+/usr/share/qemu-lite/qemu/keymaps/fr
+/usr/share/qemu-lite/qemu/keymaps/fr-be
+/usr/share/qemu-lite/qemu/keymaps/fr-ca
+/usr/share/qemu-lite/qemu/keymaps/fr-ch
+/usr/share/qemu-lite/qemu/keymaps/hr
+/usr/share/qemu-lite/qemu/keymaps/hu
+/usr/share/qemu-lite/qemu/keymaps/is
+/usr/share/qemu-lite/qemu/keymaps/it
+/usr/share/qemu-lite/qemu/keymaps/ja
+/usr/share/qemu-lite/qemu/keymaps/lt
+/usr/share/qemu-lite/qemu/keymaps/lv
+/usr/share/qemu-lite/qemu/keymaps/mk
+/usr/share/qemu-lite/qemu/keymaps/modifiers
+/usr/share/qemu-lite/qemu/keymaps/nl
+/usr/share/qemu-lite/qemu/keymaps/nl-be
+/usr/share/qemu-lite/qemu/keymaps/no
+/usr/share/qemu-lite/qemu/keymaps/pl
+/usr/share/qemu-lite/qemu/keymaps/pt
+/usr/share/qemu-lite/qemu/keymaps/pt-br
+/usr/share/qemu-lite/qemu/keymaps/ru
+/usr/share/qemu-lite/qemu/keymaps/sl
+/usr/share/qemu-lite/qemu/keymaps/sv
+/usr/share/qemu-lite/qemu/keymaps/th
+/usr/share/qemu-lite/qemu/keymaps/tr
+/usr/share/qemu-lite/qemu/kvmvapic.bin
+/usr/share/qemu-lite/qemu/linuxboot.bin
+/usr/share/qemu-lite/qemu/linuxboot_dma.bin
+/usr/share/qemu-lite/qemu/multiboot.bin
+/usr/share/qemu-lite/qemu/openbios-ppc
+/usr/share/qemu-lite/qemu/openbios-sparc32
+/usr/share/qemu-lite/qemu/openbios-sparc64
+/usr/share/qemu-lite/qemu/palcode-clipper
+/usr/share/qemu-lite/qemu/petalogix-ml605.dtb
+/usr/share/qemu-lite/qemu/petalogix-s3adsp1800.dtb
+/usr/share/qemu-lite/qemu/ppc_rom.bin
+/usr/share/qemu-lite/qemu/pxe-e1000.rom
+/usr/share/qemu-lite/qemu/pxe-eepro100.rom
+/usr/share/qemu-lite/qemu/pxe-ne2k_pci.rom
+/usr/share/qemu-lite/qemu/pxe-pcnet.rom
+/usr/share/qemu-lite/qemu/pxe-rtl8139.rom
+/usr/share/qemu-lite/qemu/pxe-virtio.rom
+/usr/share/qemu-lite/qemu/qemu-icon.bmp
+/usr/share/qemu-lite/qemu/qemu_logo_no_text.svg
+/usr/share/qemu-lite/qemu/s390-ccw.img
+/usr/share/qemu-lite/qemu/sgabios.bin
+/usr/share/qemu-lite/qemu/slof.bin
+/usr/share/qemu-lite/qemu/spapr-rtas.bin
+/usr/share/qemu-lite/qemu/trace-events-all
+/usr/share/qemu-lite/qemu/u-boot.e500
+/usr/share/qemu-lite/qemu/vgabios-cirrus.bin
+/usr/share/qemu-lite/qemu/vgabios-qxl.bin
+/usr/share/qemu-lite/qemu/vgabios-stdvga.bin
+/usr/share/qemu-lite/qemu/vgabios-virtio.bin
+/usr/share/qemu-lite/qemu/vgabios-vmware.bin
+/usr/share/qemu-lite/qemu/vgabios.bin

--- a/2.1/build/fedora/Dockerfile
+++ b/2.1/build/fedora/Dockerfile
@@ -76,10 +76,18 @@ RUN wget https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz
 RUN tar -C /usr/local -xzf go1.8.linux-amd64.tar.gz
 ENV PATH=$PATH:/usr/local/go/bin
 
-# Set $GOPATH and $HOME env variables
-RUN mkdir -p /root/go
-ENV GOPATH /root/go
-ENV HOME /root
-WORKDIR $HOME
+# Create a clear containers (cc) user
+ENV USER cc
+ENV HOME /home/cc
+RUN useradd -u 1000 -U -d ${HOME} -s /bin/bash ${USER}
+
+USER    ${USER}
+WORKDIR ${HOME}
+
+RUN mkdir -p /home/cc/go
+ENV GOPATH /home/cc/go
+
+RUN mkdir -p /home/cc/rpmbuild/SOURCES
+COPY SOURCES/* /home/cc/rpmbuild/SOURCES/
 
 CMD ["/bin/bash"]

--- a/2.1/build/fedora/README.md
+++ b/2.1/build/fedora/README.md
@@ -1,9 +1,20 @@
-# To build
-`$ sudo docker build -t fedora-clear-containers .`
+# Build the Fedora builder Docker container 
 
-# To generate the qemu-lite & cc-oci-runtime rpms just run this:
-`$ sudo docker run -ti --rm -v $PWD/../rpmbuild:/root/rpmbuild -v $PWD/../build-rpms.sh:/usr/bin/build-rpms.sh fedora-clear-containers /usr/bin/build-rpms.sh VERSION`
+```
+# docker build -t fedora-clear-containers .
+```
 
-Currently this is working with version cc-oci-runtime 2.1.1, change `VERSION` to 2.1.1
+# Generate the qemu-lite and cc-oci-runtime RPMs
 
-The rpms for cc-oci-runtime & qemu-lite will be at `$PWD/../rpmbuild/RPMS/x86_64`
+## Host build directory
+
+The RPMs will be copied into a directory of your choice, e.g. `/tmp/build`
+Make sure you have write access on that directory.
+
+```
+# export BUILD_DIR=/tmp/build
+# export VERSION=2.1.1
+# docker run -ti --rm -v $BUILD_DIR:/home/cc/build -v $PWD/../build-rpms.sh:/usr/bin/build-rpms.sh fedora-clear-containers /usr/bin/build-rpms.sh $VERSION
+```
+
+The RPMs for cc-oci-runtime and qemu-lite will be at `$BUILD_DIR`

--- a/2.1/build/fedora/SOURCES/cc-oci-runtime.spec-template
+++ b/2.1/build/fedora/SOURCES/cc-oci-runtime.spec-template
@@ -1,0 +1,131 @@
+%undefine _missing_build_ids_terminate_build
+Name:      cc-oci-runtime
+Version:   VERSION
+Release:   0
+Source0:   %{name}-%{version}.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}-root-%(%{__id_u} -n)
+Summary  : No detailed summary available
+Group    : Development/Tools
+License  : Apache-2.0 GPL-2.0
+Requires: cc-oci-runtime-bin
+Requires: cc-oci-runtime-config
+Requires: cc-oci-runtime-data
+Requires:  clear-containers-image
+Requires:  clear-containers-selinux
+Requires:  qemu-lite
+Requires:  linux-container
+
+%description
+.. contents::
+.. sectnum::
+``cc-oci-runtime``
+===================
+Overview
+--------
+
+%package bin
+Summary: bin components for the cc-oci-runtime package.
+Group: Binaries
+Requires: cc-oci-runtime-data
+Requires: cc-oci-runtime-config
+
+%description bin
+bin components for the cc-oci-runtime package.
+
+%package config
+Summary: config components for the cc-oci-runtime package.
+Group: Default
+
+%description config
+config components for the cc-oci-runtime package.
+
+%package data
+Summary: data components for the cc-oci-runtime package.
+Group: Data
+
+%description data
+data components for the cc-oci-runtime package.
+
+%package extras
+Summary: extras components for the cc-oci-runtime package.
+Group: Default
+
+%description extras
+extras components for the cc-oci-runtime package.
+
+%prep
+%setup -q -n cc-oci-runtime-PACKAGE
+
+%build
+export LANG=C
+sh ./autogen.sh --disable-static --enable-valgrind \
+--disable-cppcheck \
+--disable-tests \
+--disable-valgrind-memcheck \
+--disable-functional-tests \
+--disable-docker-tests \
+--with-cc-kernel=/usr/share/clear-containers/vmlinux.container \
+--with-cc-image=/usr/share/clear-containers/clear-containers.img \
+--with-cc-image-systemdsystemunitdir=/usr/lib/systemd/system \
+--enable-autogopath
+make V=1  %{?_smp_mflags}
+
+%check
+export LANG=C
+export http_proxy=http://127.0.0.1:9/
+export https_proxy=http://127.0.0.1:9/
+export no_proxy=localhost
+make VERBOSE=1 V=1 check
+
+%install
+rm -rf %{buildroot}
+%make_install
+
+%files
+%defattr(-,root,root,-)
+/usr/share/defaults/cc-oci-runtime/genfile.sh
+
+%files bin
+%defattr(-,root,root,-)
+/usr/bin/cc-oci-runtime
+/usr/bin/cc-oci-runtime.sh
+/usr/libexec/cc-proxy
+/usr/libexec/cc-shim
+
+%files config
+%defattr(-,root,root,-)
+%exclude /usr/lib/systemd/system/cc-agent.service
+%exclude /usr/lib/systemd/system/cc-agent.target
+%exclude /usr/lib/systemd/system/container-workload.service
+%exclude /usr/lib/systemd/system/container.target
+%exclude /usr/lib/systemd/system/opt-rootfs-proc.mount
+%exclude /usr/lib/systemd/system/opt-rootfs-sys.mount
+%exclude /usr/lib/systemd/system/opt-rootfs.mount
+/usr/lib/systemd/system/cc-proxy.service
+/usr/lib/systemd/system/cc-proxy.socket
+
+%files data
+%defattr(-,root,root,-)
+%if 0%{?suse_version}
+%dir /usr/share/defaults
+%dir /usr/share/defaults/cc-oci-runtime
+%endif
+/usr/share/defaults/cc-oci-runtime/hypervisor.args
+/usr/share/defaults/cc-oci-runtime/kernel-cmdline
+/usr/share/defaults/cc-oci-runtime/vm.json
+
+
+%files extras
+%defattr(-,root,root,-)
+/usr/lib/systemd/system/cc-agent.service
+/usr/lib/systemd/system/cc-agent.target
+/usr/lib/systemd/system/container-workload.service
+/usr/lib/systemd/system/container.target
+/usr/lib/systemd/system/opt-rootfs-proc.mount
+/usr/lib/systemd/system/opt-rootfs-sys.mount
+/usr/lib/systemd/system/opt-rootfs.mount
+
+%post
+/usr/bin/systemctl enable cc-proxy.socket
+/usr/bin/systemctl daemon-reload
+/usr/bin/systemctl restart cc-proxy.socket

--- a/2.1/build/fedora/SOURCES/configure.patch
+++ b/2.1/build/fedora/SOURCES/configure.patch
@@ -1,0 +1,12 @@
+diff --git a/configure b/configure
+index 0c0472a..5cdb77e 100755
+--- a/configure
++++ b/configure
+@@ -1145,7 +1145,6 @@ for opt do
+   *)
+       echo "ERROR: unknown option $opt"
+       echo "Try '$0 --help' for more information"
+-      exit 1
+   ;;
+   esac
+ done

--- a/2.1/build/fedora/SOURCES/qemu-lite.spec
+++ b/2.1/build/fedora/SOURCES/qemu-lite.spec
@@ -1,0 +1,214 @@
+%undefine _missing_build_ids_terminate_build
+Name: qemu-lite
+Version: 2.7.1
+Release: 0
+Source0: https://github.com/01org/qemu-lite/archive/da5004e3ffc6a79df82d1b9d8f8533c4045f193c.tar.gz
+BuildRoot: %{_tmppath}/%{name}-%{version}-%{release}
+Summary  : OpenBIOS development utilities
+Group    : Development/Tools
+License  : Apache-2.0 BSD-2-Clause BSD-3-Clause GPL-2.0 GPL-2.0+ GPL-3.0 LGPL-2.0+ LGPL-2.1 LGPL-3.0 MIT
+Requires: qemu-lite-bin
+Requires: qemu-lite-data
+Patch1: configure.patch
+
+%description
+This package contains the OpenBIOS development new utilities.
+
+There are
+* toke - an IEEE 1275-1994 compliant FCode tokenizer
+* detok - an IEEE 1275-1994 compliant FCode detokenizer
+* paflof - a forth kernel running in user space
+* an fcode bytecode evaluator running in paflof
+
+See /usr/share/doc/packages/openbios for details and examples.
+
+Authors:
+--------
+    Stefan Reinauer <stepan@openbios.net>
+    Segher Boessenkool <segher@openbios.net>
+
+%package bin
+Summary: bin components for the qemu-lite package.
+Group: Binaries
+Requires: qemu-lite-data
+
+%description bin
+bin components for the qemu-lite package.
+
+
+%package data
+Summary: data components for the qemu-lite package.
+Group: Data
+
+%description data
+data components for the qemu-lite package.
+
+
+%prep
+%setup -q -n qemu-lite-da5004e3ffc6a79df82d1b9d8f8533c4045f193c
+%patch1 -p1
+
+%build
+export LANG=C
+CC=gcc ./configure --prefix=/usr --disable-bluez \
+--disable-brlapi \
+--disable-bzip2 \
+--disable-curl \
+--disable-curses \
+--disable-debug-tcg \
+--disable-fdt \
+--disable-glusterfs \
+--disable-gtk \
+--disable-libiscsi \
+--disable-libnfs \
+--disable-libssh2 \
+--disable-libusb \
+--disable-linux-aio \
+--disable-lzo \
+--disable-opengl \
+--disable-qom-cast-debug \
+--disable-rbd \
+--disable-rdma \
+--disable-sdl \
+--disable-seccomp \
+--disable-slirp \
+--disable-snappy \
+--disable-spice \
+--disable-strip \
+--disable-tcg-interpreter \
+--disable-tcmalloc \
+--disable-tools \
+--disable-tpm \
+--disable-usb-redir \
+--disable-uuid \
+--disable-vnc \
+--disable-vnc-jpeg \
+--disable-vnc-png \
+--disable-vnc-sasl \
+--disable-vte \
+--disable-xen \
+--enable-attr \
+--enable-cap-ng \
+--enable-kvm \
+--enable-virtfs \
+--target-list=x86_64-softmmu \
+--extra-cflags="-fno-semantic-interposition -O3 -falign-functions=32" \
+--datadir=/usr/share/qemu-lite \
+--libdir=/usr/lib64/qemu-lite \
+--libexecdir=/usr/libexec/qemu-lite \
+--enable-vhost-net \
+--disable-docs
+make V=1  %{?_smp_mflags}
+
+%install
+rm -rf %{buildroot}
+%make_install
+## make_install_append content
+for file in %{buildroot}/usr/bin/*
+do
+dir=$(dirname "$file")
+bin=$(basename "$file")
+new=$(echo "$bin"|sed -e 's/qemu-/qemu-lite-/g' -e 's/ivshmem-/ivshmem-lite-/g' -e 's/virtfs-/virtfs-lite-/g')
+mv "$file" "$dir/$new"
+done
+## make_install_append end
+
+%files
+%defattr(-,root,root,-)
+
+%files bin
+%defattr(-,root,root,-)
+/usr/bin/qemu-lite-ga
+/usr/bin/qemu-lite-system-x86_64
+/usr/bin/virtfs-lite-proxy-helper
+%dir /usr/libexec
+%dir /usr/libexec/qemu-lite
+/usr/libexec/qemu-lite/qemu-bridge-helper
+
+%files data
+%defattr(-,root,root,-)
+%dir /usr/share/qemu-lite
+%dir /usr/share/qemu-lite/qemu
+%dir /usr/share/qemu-lite/qemu/keymaps
+/usr/share/qemu-lite/qemu/QEMU,cgthree.bin
+/usr/share/qemu-lite/qemu/QEMU,tcx.bin
+/usr/share/qemu-lite/qemu/acpi-dsdt.aml
+/usr/share/qemu-lite/qemu/bamboo.dtb
+/usr/share/qemu-lite/qemu/bios-256k.bin
+/usr/share/qemu-lite/qemu/bios.bin
+/usr/share/qemu-lite/qemu/efi-e1000.rom
+/usr/share/qemu-lite/qemu/efi-e1000e.rom
+/usr/share/qemu-lite/qemu/efi-eepro100.rom
+/usr/share/qemu-lite/qemu/efi-ne2k_pci.rom
+/usr/share/qemu-lite/qemu/efi-pcnet.rom
+/usr/share/qemu-lite/qemu/efi-rtl8139.rom
+/usr/share/qemu-lite/qemu/efi-virtio.rom
+/usr/share/qemu-lite/qemu/efi-vmxnet3.rom
+/usr/share/qemu-lite/qemu/keymaps/ar
+/usr/share/qemu-lite/qemu/keymaps/bepo
+/usr/share/qemu-lite/qemu/keymaps/common
+/usr/share/qemu-lite/qemu/keymaps/cz
+/usr/share/qemu-lite/qemu/keymaps/da
+/usr/share/qemu-lite/qemu/keymaps/de
+/usr/share/qemu-lite/qemu/keymaps/de-ch
+/usr/share/qemu-lite/qemu/keymaps/en-gb
+/usr/share/qemu-lite/qemu/keymaps/en-us
+/usr/share/qemu-lite/qemu/keymaps/es
+/usr/share/qemu-lite/qemu/keymaps/et
+/usr/share/qemu-lite/qemu/keymaps/fi
+/usr/share/qemu-lite/qemu/keymaps/fo
+/usr/share/qemu-lite/qemu/keymaps/fr
+/usr/share/qemu-lite/qemu/keymaps/fr-be
+/usr/share/qemu-lite/qemu/keymaps/fr-ca
+/usr/share/qemu-lite/qemu/keymaps/fr-ch
+/usr/share/qemu-lite/qemu/keymaps/hr
+/usr/share/qemu-lite/qemu/keymaps/hu
+/usr/share/qemu-lite/qemu/keymaps/is
+/usr/share/qemu-lite/qemu/keymaps/it
+/usr/share/qemu-lite/qemu/keymaps/ja
+/usr/share/qemu-lite/qemu/keymaps/lt
+/usr/share/qemu-lite/qemu/keymaps/lv
+/usr/share/qemu-lite/qemu/keymaps/mk
+/usr/share/qemu-lite/qemu/keymaps/modifiers
+/usr/share/qemu-lite/qemu/keymaps/nl
+/usr/share/qemu-lite/qemu/keymaps/nl-be
+/usr/share/qemu-lite/qemu/keymaps/no
+/usr/share/qemu-lite/qemu/keymaps/pl
+/usr/share/qemu-lite/qemu/keymaps/pt
+/usr/share/qemu-lite/qemu/keymaps/pt-br
+/usr/share/qemu-lite/qemu/keymaps/ru
+/usr/share/qemu-lite/qemu/keymaps/sl
+/usr/share/qemu-lite/qemu/keymaps/sv
+/usr/share/qemu-lite/qemu/keymaps/th
+/usr/share/qemu-lite/qemu/keymaps/tr
+/usr/share/qemu-lite/qemu/kvmvapic.bin
+/usr/share/qemu-lite/qemu/linuxboot.bin
+/usr/share/qemu-lite/qemu/linuxboot_dma.bin
+/usr/share/qemu-lite/qemu/multiboot.bin
+/usr/share/qemu-lite/qemu/openbios-ppc
+/usr/share/qemu-lite/qemu/openbios-sparc32
+/usr/share/qemu-lite/qemu/openbios-sparc64
+/usr/share/qemu-lite/qemu/palcode-clipper
+/usr/share/qemu-lite/qemu/petalogix-ml605.dtb
+/usr/share/qemu-lite/qemu/petalogix-s3adsp1800.dtb
+/usr/share/qemu-lite/qemu/ppc_rom.bin
+/usr/share/qemu-lite/qemu/pxe-e1000.rom
+/usr/share/qemu-lite/qemu/pxe-eepro100.rom
+/usr/share/qemu-lite/qemu/pxe-ne2k_pci.rom
+/usr/share/qemu-lite/qemu/pxe-pcnet.rom
+/usr/share/qemu-lite/qemu/pxe-rtl8139.rom
+/usr/share/qemu-lite/qemu/pxe-virtio.rom
+/usr/share/qemu-lite/qemu/qemu-icon.bmp
+/usr/share/qemu-lite/qemu/qemu_logo_no_text.svg
+/usr/share/qemu-lite/qemu/s390-ccw.img
+/usr/share/qemu-lite/qemu/sgabios.bin
+/usr/share/qemu-lite/qemu/slof.bin
+/usr/share/qemu-lite/qemu/spapr-rtas.bin
+/usr/share/qemu-lite/qemu/trace-events-all
+/usr/share/qemu-lite/qemu/u-boot.e500
+/usr/share/qemu-lite/qemu/vgabios-cirrus.bin
+/usr/share/qemu-lite/qemu/vgabios-qxl.bin
+/usr/share/qemu-lite/qemu/vgabios-stdvga.bin
+/usr/share/qemu-lite/qemu/vgabios-virtio.bin
+/usr/share/qemu-lite/qemu/vgabios-vmware.bin
+/usr/share/qemu-lite/qemu/vgabios.bin


### PR DESCRIPTION
When cloning and building as non root, our SOURCES files would show as belonging to UID and GID 1000, which are unknown to the container workloads. To resolve that issue we:

- Added a cc user with UID 1000 and GID 1000.
- Copy SOURCES into the container fs (We no longer mount it).

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>