### PR TITLE
Update Dockerfile for clearlinux

### DIFF
--- a/2.1/run/clearlinux/Dockerfile
+++ b/2.1/run/clearlinux/Dockerfile
@@ -18,25 +18,23 @@ FROM clearlinux:latest
 
 MAINTAINER Manohar Castelino "manohar.r.castelino@intel.com"
 
-RUN swupd update -s && \
-    swupd update && \
-    swupd bundle-add containers-virt
+#Run swupd multiple time for now so that we upgrade across format bumps
+#This ensures you always have the latest clearlinux image even if the 
+#one on dockerhub has not been updated
+#This also works around the overlay file system bug
+#Add a workaround for docker bug https://github.com/moby/moby/issues/31805
+RUN /bin/sh -c 'swupd update; \
+                swupd update; \
+                swupd update; \
+                swupd update; \
+                swupd update;'
+
+RUN swupd bundle-add containers-virt
 
 RUN mkdir -p /var/run/ && \
     mkdir -p /etc/docker/ && \
     mkdir -p /run/opencontainer/containers/
     
-# Run swupd multiple time for now so that we upgrade across format bumps
-# This ensures you always have the latest clearlinux image even if the
-# one on dockerhub has not been updated
-RUN swupd update
-
-RUN swupd update
-
-RUN swupd update
-
-RUN swupd update
-
 RUN echo -e "#!/bin/bash\ndockerd --add-runtime cor=/usr/bin/cc-oci-runtime \
 	--default-runtime=cor --host=unix:///var/run/docker.sock --host=tcp://0.0.0.0:2375 \
 	--storage-driver=vfs &> /tmp/docker.log &\n/usr/libexec/cc-proxy &" > \


### PR DESCRIPTION
Add a workaround for docker bug https://github.com/moby/moby/issues/31805

When using the overlay storage driver, a file modification is not detected by Docker when the file's modification time remains unchanged. 
Once dockerhub switches to graph driver that does not have this limitation, this workaround is not needed.